### PR TITLE
Use webbrowser.open to open url instead of os.startfile

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -146,7 +146,7 @@ class Generator:
         encoded = base64.urlsafe_b64encode(compressed).decode().rstrip("=")
         
         url = f"https://fortnite.gg/my-locker?items={encoded}"
-        os.startfile(url)
+        webbrowser.open(url)
 
         await self.http.close()
         log.info("Link successfully copied to the clipboard. Press enter to close the program.")


### PR DESCRIPTION
`os.startfile()` does not exist on non-Windows operating systems and will throw an error. Since you're using it to open a url, you can just use `webbrowser.open()`. Fixes error on non-Windows systems.